### PR TITLE
Fix Java 9 surefire listeners issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,6 @@
-# Compiled class file
+generated
+
 *.class
-
-# Log file
-*.log
-
-# BlueJ files
-*.ctxt
 
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/
@@ -14,9 +9,106 @@
 *.jar
 *.war
 *.ear
-*.zip
-*.tar.gz
-*.rar
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+*.pydevproject
+.metadata
+.gradle
+bin/
+tmp/
+*.tmp
+*.bak
+*.swp
+*~.nib
+local.properties
+.settings/
+.loadpath
+
+# Eclipse Core
+.project
+
+# External tool builders
+.externalToolBuilders/
+
+# Locally stored "Eclipse launch configurations"
+*.launch
+
+# CDT-specific
+.cproject
+
+# JDT-specific (Eclipse Java Development Tools)
+.classpath
+
+# Java annotation processor (APT)
+.factorypath
+
+# PDT-specific
+.buildpath
+
+# sbteclipse plugin
+.target
+
+# TeXlipse plugin
+.texlipse
+
+# STS (Spring Tool Suite)
+.springBeans
+
+# Windows image file caches
+Thumbs.db
+ehthumbs.db
+
+# Folder config file
+Desktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msm
+*.msp
+# Windows shortcuts
+*.lnk
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+/.project
+/.settings/
+/.classpath
+*.classpath
+*.project
+*.classpath
+*.project
+/.apt_generated/
+
+# IntelliJ Idea
+.idea/
+*.iml
+*.ipr
+*.iws
+out/
+
+# Netbeans
+nbproject/private/
+build/
+nbbuild/
+dist/
+nbdist/
+nbactions.xml
+nb-configuration.xml
+.nb-gradle/
+
+# Test output log file
+log*.txt*
+.DS_Store
+.vscode/

--- a/pom.xml
+++ b/pom.xml
@@ -38,12 +38,6 @@
 					<includes>
 						<include>**/*Test.java</include>
 					</includes>
-					<properties>
-						<property>
-							<name>listener</name>
-				        	<value>org.test.Listener</value>
-						</property>
-					</properties>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/src/main/java/org/test/FirstTest.java
+++ b/src/main/java/org/test/FirstTest.java
@@ -1,8 +1,11 @@
 package org.test;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
+@RunWith(MyRunner.class)
 public class FirstTest {
+
 	@Test
 	public void test() {
 		System.out.println("This is test");

--- a/src/main/java/org/test/MyRunner.java
+++ b/src/main/java/org/test/MyRunner.java
@@ -1,0 +1,38 @@
+package org.test;
+
+import org.junit.AssumptionViolatedException;
+import org.junit.internal.runners.model.EachTestNotifier;
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runner.notification.StoppedByUserException;
+import org.junit.runners.BlockJUnit4ClassRunner;
+import org.junit.runners.model.InitializationError;
+import org.junit.runners.model.Statement;
+public class MyRunner extends BlockJUnit4ClassRunner {
+
+  public MyRunner (Class<?> klass) throws InitializationError {
+    super(klass);
+  }
+
+  @Override
+  public void run (RunNotifier notifier) {
+    //Add Listener. This will register our JUnit Listener.
+    notifier.addListener(new Listener());
+    //Get each test notifier
+    EachTestNotifier testNotifier = new EachTestNotifier(notifier, getDescription());
+    try {
+      //In order capture testRunStarted method
+      //at the very beginning of the test run, we will add below code.
+      //Invoke here the run testRunStarted() method
+      notifier.fireTestRunStarted(getDescription());
+      Statement statement = classBlock(notifier);
+      statement.evaluate();
+
+    } catch (AssumptionViolatedException e) {
+      testNotifier.fireTestIgnored();
+    } catch (StoppedByUserException e) {
+      throw e;
+    } catch (Throwable e) {
+      testNotifier.addFailure(e);
+    }
+  }
+}


### PR DESCRIPTION
Use @RunWith annotation for overriding default runner and add needed listeners.

Surefire's approach is not portable anyway (I mean, what we are going to do if we need to migrate from Maven to Gradle???)